### PR TITLE
fix: hydrate.sh nomos vet

### DIFF
--- a/scripts/kpt/hydrate.sh
+++ b/scripts/kpt/hydrate.sh
@@ -94,7 +94,7 @@ function hydrate-env () {
     # map deploy directory to docker then run nomos vet from image
     # volume mapping need absolute path
     print_info "Running 'nomos vet' on ${env_deploy_dir} ..."
-    docker run -v "$PWD/${env_deploy_dir}:/${env_deploy_dir}" gcr.io/config-management-release/nomos:stable nomos vet --no-api-server-check --source-format unstructured --path "/${env_deploy_dir}"
+    docker run -v "$PWD/${env_deploy_dir}:/${env_deploy_dir}" gcr.io/config-management-release/nomos:v1.14.0-rc.1 nomos vet --no-api-server-check --source-format unstructured --path "/${env_deploy_dir}"
 
     print_success "function 'hydrate-env ${1}' finished successfully."
 }

--- a/scripts/kpt/hydrate.sh
+++ b/scripts/kpt/hydrate.sh
@@ -93,6 +93,7 @@ function hydrate-env () {
 
     # map deploy directory to docker then run nomos vet from image
     # volume mapping need absolute path
+    # pinned version v1.14.0-rc.1 to avoid command not found error with stable tag
     print_info "Running 'nomos vet' on ${env_deploy_dir} ..."
     docker run -v "$PWD/${env_deploy_dir}:/${env_deploy_dir}" gcr.io/config-management-release/nomos:v1.14.0-rc.1 nomos vet --no-api-server-check --source-format unstructured --path "/${env_deploy_dir}"
 


### PR DESCRIPTION
nomos vet returns error: unknown command when using the `stable` tag.
![image](https://user-images.githubusercontent.com/85115688/220196795-b695fcd9-812f-41c2-bda8-4e85f0e44594.png)

using v1.14.0-rc.1 fix the problem
