### PR TITLE
update .markdown-lint-config.yaml with MD30

### DIFF
--- a/.github/linter-rules/.markdown-lint-config.yaml
+++ b/.github/linter-rules/.markdown-lint-config.yaml
@@ -24,6 +24,7 @@ MD024: false                  # no-duplicate-header, fails on CHANGELOG.md
 MD026:
   punctuation: ".,;:!。，；:"  # List of not allowed
 MD029: false                  # Ordered list item prefix
+MD030: false                  # disable list-marker-space, generate kpt docs would make it fail
 MD033: false                  # Allow inline HTML
 MD036: false                  # Emphasis used instead of a heading
 


### PR DESCRIPTION
* Updated .markdown-lint-config.yaml with 'false' MD30 rule - Spaces after list markers