### PR TITLE
feat: compare setters key function

### DIFF
--- a/scripts/kpt/hydrate.sh
+++ b/scripts/kpt/hydrate.sh
@@ -109,8 +109,36 @@ hydrate_env () {
                     print_error "Missing customization: ${SOURCE_CUSTOMIZATION_DIR}/${environment}/${setters_file}"
                     error_counter=$((error_counter+1))
                     status_validate_setters["${dir_id}"]=1
+                                # check if there are any missing keys between the source base and source customizations setters files
+                else
+                    # Create temp dir for comparing of keys
+                    mkdir -p "${env_temp_subdir}/compare-keys"
+                    echo "${SOURCE_BASE_DIR}/${setters_file}"
+                    echo "${SOURCE_CUSTOMIZATION_DIR}/${environment}/${setters_file}"
+                    # Fetch keys in first setters file
+                    yq eval '.data | sort_keys(.) | keys' "${SOURCE_BASE_DIR}/${setters_file}" | yq '... comments=""' > "${env_temp_subdir}/compare-keys/source_base_setters.yaml"
+                    # Fetch keys in second setters file
+                    yq eval '.data | sort_keys(.) | keys' "${SOURCE_CUSTOMIZATION_DIR}/${environment}/${setters_file}" | yq '... comments=""' > "${env_temp_subdir}/compare-keys/source_customization_setters.yaml"
+                    # compare keys between source-base and source-customization setters files
+                    result=$(comm -3 --nocheck-order "${env_temp_subdir}/compare-keys/source_base_setters.yaml" "${env_temp_subdir}/compare-keys/source_customization_setters.yaml")
+                    # Check the exit code of the comm command
+                    if [ $? -ne 0 ]; then
+                        print_error "Compare command failed with error code $?"
+                        error_counter=$((error_counter+1))
+                        status_validate_setters["${dir_id}"]=1
+                    fi
+                    # Check if there were any differences
+                    if [ -n "$result" ]; then
+                        print_error "Missing key(s) detected. The following keys are missing."
+                        echo -e "$result\n"
+                        # Add a line break after error output for clarity
+                        echo
+                        error_counter=$((error_counter+1))
+                        status_validate_setters["${dir_id}"]=1
+                    else
+                        echo -e "No missing key(s) detected\n"
+                    fi
                 fi
-                # TODO: possible enhancement, maybe check if there is a diff?
             done
             # exit function if errors were found
             if [[ "${status_validate_setters[${dir_id}]}" -ne 0 ]] ; then

--- a/scripts/kpt/hydrate.sh
+++ b/scripts/kpt/hydrate.sh
@@ -109,7 +109,8 @@ hydrate_env () {
                     print_error "Missing customization: ${SOURCE_CUSTOMIZATION_DIR}/${environment}/${setters_file}"
                     error_counter=$((error_counter+1))
                     status_validate_setters["${dir_id}"]=1
-                                # check if there are any missing keys between the source base and source customizations setters files
+                
+                # check if there are any missing keys between the source base and source customizations setters files
                 else
                     # Create temp dir for comparing of keys
                     mkdir -p "${env_temp_subdir}/compare-keys"

--- a/scripts/kpt/hydrate.sh
+++ b/scripts/kpt/hydrate.sh
@@ -133,8 +133,6 @@ hydrate_env () {
                     if [ -n "$result" ]; then
                         print_error "Missing key(s) detected. The following keys are missing."
                         echo -e "$result\n"
-                        # Add a line break after error output for clarity
-                        echo
                         error_counter=$((error_counter+1))
                         status_validate_setters["${dir_id}"]=1
                     else

--- a/scripts/kpt/hydrate.sh
+++ b/scripts/kpt/hydrate.sh
@@ -125,7 +125,7 @@ hydrate_env () {
                     # Check the exit code of the comm command
                     comm_err_check=$?
                     if [ $comm_err_check -ne 0 ]; then
-                        print_error "Compare command failed with error code $?"
+                        print_error "Compare command failed with error code $comm_err_check"
                         error_counter=$((error_counter+1))
                         status_validate_setters["${dir_id}"]=1
                     fi

--- a/scripts/kpt/hydrate.sh
+++ b/scripts/kpt/hydrate.sh
@@ -122,13 +122,6 @@ hydrate_env () {
                     yq eval '.data | sort_keys(.) | keys' "${SOURCE_CUSTOMIZATION_DIR}/${environment}/${setters_file}" | yq '... comments=""' > "${env_temp_subdir}/compare-keys/source_customization_setters.yaml"
                     # compare keys between source-base and source-customization setters files
                     result=$(comm -3 --nocheck-order "${env_temp_subdir}/compare-keys/source_base_setters.yaml" "${env_temp_subdir}/compare-keys/source_customization_setters.yaml")
-                    # Check the exit code of the comm command
-                    comm_err_check=$?
-                    if [ $comm_err_check -ne 0 ]; then
-                        print_error "Compare command failed with error code $comm_err_check"
-                        error_counter=$((error_counter+1))
-                        status_validate_setters["${dir_id}"]=1
-                    fi
                     # Check if there were any differences
                     if [ -n "$result" ]; then
                         print_error "Missing key(s) detected. The following keys are missing."

--- a/scripts/kpt/hydrate.sh
+++ b/scripts/kpt/hydrate.sh
@@ -123,7 +123,8 @@ hydrate_env () {
                     # compare keys between source-base and source-customization setters files
                     result=$(comm -3 --nocheck-order "${env_temp_subdir}/compare-keys/source_base_setters.yaml" "${env_temp_subdir}/compare-keys/source_customization_setters.yaml")
                     # Check the exit code of the comm command
-                    if [ $? -ne 0 ]; then
+                    comm_err_check=$?
+                    if [ $comm_err_check -ne 0 ]; then
                         print_error "Compare command failed with error code $?"
                         error_counter=$((error_counter+1))
                         status_validate_setters["${dir_id}"]=1


### PR DESCRIPTION
As per TODO:

**As a Platform Admin**
I want the hydrate script to flag when there is any mismatch in keys between source-base and source-customization occurs.

To help avoid errors or unexpected behavior/configuration in package upgrades or deployments

**Requirements / Features**
- Create a temp directory to use for key comparison
- Fetch keys from the source base and source customization directories and send them to the temp folder for comparison
- Compare the keys between the source base and source customization setters files
- Compare ignores comments in setters files
- Exit on any compare `comm` command errors and bump error count
- Report any differences and bump error count
- Report on no errors/diffs compares