### PR TITLE
#3 - add 30s sleep before enabling project services

### DIFF
--- a/scripts/bootstrap/setup-kcc.sh
+++ b/scripts/bootstrap/setup-kcc.sh
@@ -27,6 +27,8 @@ gcloud resource-manager folders create --display-name="$LZ_FOLDER_NAME" --organi
 gcloud projects create "$PROJECT_ID" --set-as-default --organization="$ORG_ID"
 gcloud beta billing projects link "$PROJECT_ID" --billing-account "$BILLING_ID"
 gcloud config set project "$PROJECT_ID"
+echo "sleep 30s to allow for project creation before enabling services"
+sleep 30
 gcloud services enable krmapihosting.googleapis.com container.googleapis.com cloudresourcemanager.googleapis.com cloudbilling.googleapis.com serviceusage.googleapis.com servicedirectory.googleapis.com dns.googleapis.com
 
 # VPC


### PR DESCRIPTION
The setup-kcc.sh script will fail just after project creation on service enablement  755 the script first and check the folder name via https://github.com/ssc-spc-ccoe-cei/gcp-tools/issues/36

prereq
```
admin_@cloudshell:~/pdt-arg/ssc-spc-ccoe-cei/gcp-tools/scripts/bootstrap (pdt-arg)$ export PROJECT_ID=pdt-arg
admin_@cloudshell:~/pdt-arg/ssc-spc-ccoe-cei/gcp-tools/scripts/bootstrap (pdt-arg)$ export BILLING_ID=$(gcloud alpha billing projects describe $PROJECT_ID '--format=value(billingAccountName)' | sed 's/.*\///')

```
Without delay - error on service enablement
gcloud services enable krmapihosting.googleapis.com container.googleapis.com cloudresourcemanager.googleapis.com cloudbilling.googleapis.com serviceusage.googleapis.com servicedirectory.googleapis.com dns.googleapis.com

```
admin_@cloudshell:~/pdt-arg/ssc-spc-ccoe-cei/gcp-tools/scripts/bootstrap (pdt-arg)$ ./setup-kcc.sh pdt-arg.env 
Waiting for [operations/cf.6706720371711144989] to finish...done.                                                                                                                                    
Created [<Folder
 createTime: '2023-05-23T20:59:06.933Z'
 displayName: 'pdt-arg-kcc3'
 lifecycleState: LifecycleStateValueValuesEnum(ACTIVE, 1)
 name: 'folders/660809831186'
 parent: 'organizations/226082700214'>].
folders/660809831186
Create in progress for [https://cloudresourcemanager.googleapis.com/v1/projects/pdt-arg-kcc3].
Waiting for [operations/cp.4644309476357033103] to finish...done.                                                                                                                                    
Enabling service [cloudapis.googleapis.com] on project [pdt-arg-kcc3]...
Operation "operations/acat.p2-81626023040-f22e32d2-4747-4294-b0ee-f3655f75bef0" finished successfully.
Updated property [core/project] to [pdt-arg-kcc3].
billingAccountName: billingAccounts/01A5...82
billingEnabled: true
name: projects/pdt-arg-kcc3/billingInfo
projectId: pdt-arg-kcc3
Updated property [core/project].
ERROR: (gcloud.services.enable) The operation "operations/acf.p2-81626023040-3da1a577-4be7-4587-ad1c-c46f1bdf53b9" resulted in a failure "[service pubsub.googleapis.com encountered internal error: type: "googleapis.com" subject: "160009" ] with failed services [pubsub.googleapis.com]".
Details: "[<DetailsValueListEntry
 additionalProperties: [<AdditionalProperty
 key: '@type'
 value: <JsonValue
 string_value: 'type.googleapis.com/google.rpc.PreconditionFailure'>>, <AdditionalProperty
 key: 'violations'
 value: <JsonValue
 array_value: <JsonArray
 entries: [<JsonValue
 object_value: <JsonObject
 properties: [<Property
 key: 'type'
 value: <JsonValue
 string_value: 'googleapis.com'>>, <Property
 key: 'subject'
 value: <JsonValue
 string_value: '160009'>>]>>]>>>]>]".
admin_@cloudshell:~/pdt-arg/ssc-spc-ccoe-cei/gcp-tools/scripts/bootstrap (pdt-arg-kcc3)$ 
```

With delay

```
admin_@cloudshell:~/pdt-arg/ssc-spc-ccoe-cei/gcp-tools/scripts/bootstrap (pdt-arg)$ ./setup-kcc.sh pdt-arg.env 
Waiting for [operations/cf.4958894206208153244] to finish...done.                                                                                                                                    
Created [<Folder
 createTime: '2023-05-23T20:47:31.568Z'
 displayName: 'pdt-arg-kcc2'
 lifecycleState: LifecycleStateValueValuesEnum(ACTIVE, 1)
 name: 'folders/121716562974'
 parent: 'organizations/226082700214'>].
folders/121716562974
Create in progress for [https://cloudresourcemanager.googleapis.com/v1/projects/pdt-arg-kcc2].
Waiting for [operations/cp.6286887151888078406] to finish...done.                                                                                                                                    
Enabling service [cloudapis.googleapis.com] on project [pdt-arg-kcc2]...
Operation "operations/acat.p2-105687371346-1ee2f0c8-7d78-4f61-9d50-fd08dff85b40" finished successfully.
Updated property [core/project] to [pdt-arg-kcc2].
billingAccountName: billingAccounts/01A5....D82
billingEnabled: true
name: projects/pdt-arg-kcc2/billingInfo
projectId: pdt-arg-kcc2
Updated property [core/project].
sleep 30s to allow for project creation before enabling services
Operation "operations/acf.p2-105687371346-384a5ee1-7c72-4b4d-83ed-5c692c639a40" finished successfully.
```