### PR TITLE
fix: results column in hydrate and kpt-push

### DIFF
--- a/scripts/kpt/hydrate.sh
+++ b/scripts/kpt/hydrate.sh
@@ -17,7 +17,7 @@ set -o errexit
 set -o pipefail
 
 # pin kpt and nomos versions
-KPT_VERSION='v1.0.0-beta.35'
+KPT_VERSION='v1.0.0-beta.21'
 NOMOS_VERSION='v1.14.2'
 
 # the standard directory structure for processing customization and hydration

--- a/scripts/kpt/hydrate.sh
+++ b/scripts/kpt/hydrate.sh
@@ -17,7 +17,7 @@ set -o errexit
 set -o pipefail
 
 # pin kpt and nomos versions
-KPT_VERSION='v1.0.0-beta.21'
+KPT_VERSION='v1.0.0-beta.35'
 NOMOS_VERSION='v1.14.2'
 
 # the standard directory structure for processing customization and hydration
@@ -334,11 +334,11 @@ then
     echo "nomos vet: The result of validating hydrated files in '${DEPLOY_DIR}/{env_subdir} with 'nomos vet'."
 
     # printf can be used to format column width, however, it does not work with unicode emojis (used in print_status)
-    printf '\n\n%-40s%-10s%-10s%-10s%-10s%-10s\n' 'processed directory' '  setters' '    kpt' ' no diff' ' kubeval' 'nomos vet'
+    printf '\n\n%-67s%-10s%-10s%-10s%-10s%-10s\n' 'processed directory' '  setters' '    kpt' ' no diff' ' kubeval' 'nomos vet'
     # loop through all processed directories and lookup its status in each dictionary array
     for processed_dir in "${processed_dir_list[@]}"
     do
-        printf "%-40s" "${processed_dir}"
+        printf "%-67s" "${processed_dir}"
         print_status "${status_validate_setters[${processed_dir}]}"
         print_status "${status_kpt[${processed_dir}]}"
         print_status "${status_render_diff[${processed_dir}]}"

--- a/scripts/kpt/push.sh
+++ b/scripts/kpt/push.sh
@@ -67,11 +67,12 @@ if [ -f Kptfile ]; then
     #################
 
     # delete content of destination folder
-    if rm -r "$dstDir"; then
+    if rm -rf "$dstDir"; then
       print_info "erasing destination folder"
     fi
     # copy all files and folders to the specified directory within the repository
-    cp -r "$srcDir" "$dstDir"
+    mkdir -p "$dstDir"
+    cp -r "$srcDir"/* "$dstDir"
     cd "$dstDir" || exit
 
     #################


### PR DESCRIPTION
- hydrate.sh - fixed column width in result summary to support up to 67 characters for folder names
- push.sh - fixed folder creation issue
![image](https://github.com/ssc-spc-ccoe-cei/gcp-tools/assets/85115688/4ba39a4c-0254-4c80-9478-28ef1f049a54)
