### PR TITLE
Feat: Update KCC setup for private cluster

### DIFF
--- a/scripts/bootstrap/README.md
+++ b/scripts/bootstrap/README.md
@@ -1,0 +1,27 @@
+# Bootstrap the Config Controller Project
+
+The `setup-kcc.sh` automated script creates a project, the FW settings, a Cloud router, a Cloud NAT, a private service connect endpoint and a private Anthos Config Controller cluster.
+
+The script requires a `.env` file to deploy the environment.
+
+1. Your terminal should now be at the root of your `tier1` monorepo, on a new branch and with the tools submodule populated.
+
+2. If it doesn't exist, create a `bootstrap/<env>` directory. It will be used to backup files generated during bootstrapping.
+
+3. Copy the example.env file from the `tools/scripts/bootstrap` folder.
+
+```bash
+cp tools/scripts/bootstrap/.env.sample bootstrap/<ENV>/.env
+```
+
+4. **Important** Customize the new file with the appropriate values for the landing zone you are building.
+
+5. Run the `setup-kcc` automated script:
+
+```bash
+bash tools/scripts/bootstrap/setup-kcc.sh [-af] <PATH TO .ENV FILE>
+```
+- `-a`: autopilot. It will deploy an autopilot cluster instead of a standard cluster.
+- `-f`: folder_opt. It will bootstrap the landing zone in a folder instead than at the org level.
+
+The config cluster is a private cluster and can only be accessed privately from within the VPC. This requires provisioning of a virtual machine to serve as a bastion host / proxy to access the private cluster.

--- a/scripts/bootstrap/README.md
+++ b/scripts/bootstrap/README.md
@@ -26,55 +26,22 @@ bash tools/scripts/bootstrap/setup-kcc.sh [-af] <PATH TO .ENV FILE>
 
 The config cluster is a private cluster and can only be accessed privately from within the VPC. This requires provisioning of a virtual machine to serve as a bastion host / proxy to access the private cluster.
 
-## `git-creds` configuration
+## IAM and Access Configuration
 
-Once a bastion host / proxy vm is configured, to complete the configuration of the Anthos config controller cluster, `git-creds` secret must be configured in the cluster.  This secret contains credentials used to access the Git repository with the cloud resources code that the config controller will provision.
+Once a bastion host / proxy vm is configured, to complete the configuration, few additional tasks need to be performed:
+- the Google IAM policy bindings need to be configured
+- `git-creds` secret must be configured in the cluster. This secret contains credentials used to access the Git repository with the cloud resources code that the config controller will provision
+- `root-sync` must be configured
 
-To create the secret:
+The `configure-kcc-access.sh` script implements these required tasks. The script requires a `.env` file to configure the required variables.  This is the same `.env` file used by the `setup-kcc.sh` script. The script also requires a `TOKEN` variable that contains git access credentials.
+
+To run the script:
 
 ```bash
-# For Azure Devops, this is the name of the Organization
-export GIT_USERNAME=<Git-Username>
-
 # Export a TOKEN variable. Set its value to the PAT which has read access to the tier1 monorepo.
 export TOKEN='xxxxxxxxxxxxxxx'
 
-# Create git-creds secret
-kubectl create secret generic git-creds --namespace="config-management-system" --from-literal=username="${GIT_USERNAME}" --from-literal=token="${TOKEN}"
+bash tools/scripts/bootstrap/configure-kcc-access.sh.sh <PATH TO .ENV FILE>
 ```
 
-## `root-sync` Configuration
-
-Once the `git-creds` secret is created, the final step to configure the config controller cluster is to create a `RootSync` resource:
-
-```bash
-# Tier1 repo URL
-export CONFIG_SYNC_REPO=<Repo for Config Sync> # tierX repo URL
-export CONFIG_SYNC_VERSION='HEAD'
-# Should default to csync/deploy/<env>
-export CONFIG_SYNC_DIR=<Directory for config sync repo which syncs>
-
-# Create the Root Sync yaml file
-cat << EOF > ./root-sync.yaml
-apiVersion: configsync.gke.io/v1beta1
-kind: RootSync
-metadata:
-  name: root-sync
-  namespace: config-management-system
-spec:
-  sourceFormat: unstructured
-  git:
-    repo: "${CONFIG_SYNC_REPO}"
-    branch: main # eg. : main
-    dir: "${CONFIG_SYNC_DIR}" # eg.: csync/deploy/<env>
-    revision: "${CONFIG_SYNC_VERSION}"
-    auth: token
-    secretRef:
-      name: git-creds
-EOF
-
-# Apply root sync
-kubectl apply -f root-sync.yaml
-```
-
-The root-sync.yaml file should be checked into the tier1 repo
+The script generates a `root-sync.yaml` file.  This file should be checked into the tier1 repo

--- a/scripts/bootstrap/README.md
+++ b/scripts/bootstrap/README.md
@@ -41,7 +41,7 @@ To run the script:
 # Export a TOKEN variable. Set its value to the PAT which has read access to the tier1 monorepo.
 export TOKEN='xxxxxxxxxxxxxxx'
 
-bash tools/scripts/bootstrap/configure-kcc-access.sh.sh <PATH TO .ENV FILE>
+bash tools/scripts/bootstrap/configure-kcc-access.sh <PATH TO .ENV FILE>
 ```
 
 The script generates a `root-sync.yaml` file.  This file should be checked into the tier1 repo

--- a/scripts/bootstrap/README.md
+++ b/scripts/bootstrap/README.md
@@ -26,6 +26,8 @@ bash tools/scripts/bootstrap/setup-kcc.sh [-af] <PATH TO .ENV FILE>
 
 The config cluster is a private cluster and can only be accessed privately from within the VPC. This requires provisioning of a virtual machine to serve as a bastion host / proxy to access the private cluster.
 
+> Note that if your organization has an organization policy restricting VPC peering, it causes an issue when deploying the Anthos Config Controller cluster.  During cluster creation, a VPC peering is required with a Google owned project that contains the cluster control plane. To prevent this issue, a policy exemption for VPC peering should be created at the folder or project level.
+
 ## IAM and Access Configuration
 
 Once a bastion host / proxy vm is configured, to complete the configuration, few additional tasks need to be performed:

--- a/scripts/bootstrap/README.md
+++ b/scripts/bootstrap/README.md
@@ -19,12 +19,13 @@ cp tools/scripts/bootstrap/.env.sample bootstrap/<ENV>/.env
 5. Run the `setup-kcc` automated script:
 
 ```bash
-bash tools/scripts/bootstrap/setup-kcc.sh [-af] <PATH TO .ENV FILE>
+bash tools/scripts/bootstrap/setup-kcc.sh [-afp] <PATH TO .ENV FILE>
 ```
 - `-a`: autopilot. It will deploy an autopilot cluster instead of a standard cluster.
 - `-f`: folder_opt. It will bootstrap the landing zone in a folder instead than at the org level.
+- `-p`: public_endpoint_opt. It will deploy a cluster with a publicly accessible endpoint. Useful for development/testing purposes.
 
-The config cluster is a private cluster and can only be accessed privately from within the VPC. This requires provisioning of a virtual machine to serve as a bastion host / proxy to access the private cluster.
+By default, the config cluster is a private cluster and can only be accessed privately from within the VPC. This requires provisioning of a virtual machine to serve as a bastion host / proxy to access the private cluster.
 
 > Note that if your organization has an organization policy restricting VPC peering, it causes an issue when deploying the Anthos Config Controller cluster.  During cluster creation, a VPC peering is required with a Google owned project that contains the cluster control plane. To prevent this issue, a policy exemption for VPC peering should be created at the folder or project level.
 
@@ -36,6 +37,8 @@ Once a bastion host / proxy vm is configured, to complete the configuration, few
 - `root-sync` must be configured
 
 The `configure-kcc-access.sh` script implements these required tasks. The script requires a `.env` file to configure the required variables.  This is the same `.env` file used by the `setup-kcc.sh` script. The script also requires a `TOKEN` variable that contains git access credentials.
+
+> **NOTE**: The script requires connectivity to the cluster (in case of private cluster).
 
 To run the script:
 

--- a/scripts/bootstrap/configure-kcc-access.sh
+++ b/scripts/bootstrap/configure-kcc-access.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+# script to bootstrap a Config Controller project
+
+# Bash safeties: exit on error, pipelines can't hide errors
+set -o errexit
+set -o pipefail
+
+# get the directory of this script
+SCRIPT_ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# source print-colors.sh for better readability of the script's outputs
+# shellcheck source-path=scripts/bootstrap # tell shellcheck where to look
+source "${SCRIPT_ROOT}/../common/print-colors.sh"
+
+if [ $# -eq 0 ]; then
+    print_error "Usage: bash configure-kcc-access.sh PATH_TO_ENV_FILE"
+    exit 1
+fi
+
+# source the env file
+# shellcheck disable=SC1090 # don't look for sourced file, it won't exist in this repo
+source "$1"
+
+SA_EMAIL="$(kubectl get ConfigConnectorContext -n config-control \
+    -o jsonpath='{.items[0].spec.googleServiceAccount}' 2> /dev/null)"
+
+print_info "Create organization Admin IAM policy binding"
+gcloud organizations add-iam-policy-binding "${ORG_ID}" \
+  --member="serviceAccount:${SA_EMAIL}" \
+  --role=roles/resourcemanager.organizationAdmin \
+  --condition=None
+
+print_info "Create project IAM policy binding"
+gcloud projects add-iam-policy-binding "${PROJECT_ID}" \
+  --member "serviceAccount:${SA_EMAIL}" \
+  --role "roles/serviceusage.serviceUsageConsumer" \
+  --project "${PROJECT_ID}"
+
+print_info "Create git-creds for Repo access"
+kubectl create secret generic git-creds --namespace="config-management-system" --from-literal=username="${GIT_USERNAME}" --from-literal=token="${TOKEN}"
+
+cat << EOF > ./root-sync.yaml
+apiVersion: configsync.gke.io/v1beta1
+kind: RootSync
+metadata:
+  name: root-sync
+  namespace: config-management-system
+spec:
+  sourceFormat: unstructured
+  git:
+    repo: "${CONFIG_SYNC_REPO}"
+    branch: main # eg. : main
+    dir: "${CONFIG_SYNC_DIR}" # eg.: csync/deploy/<env>
+    revision: "${CONFIG_SYNC_VERSION}"
+    auth: token
+    secretRef:
+      name: git-creds
+EOF
+
+print_info "Apply root sync"
+kubectl apply -f root-sync.yaml
+
+# Further steps
+print_warning "The root-sync.yaml file should be checked into the <tier1-REPO>"

--- a/scripts/bootstrap/setup-kcc.sh
+++ b/scripts/bootstrap/setup-kcc.sh
@@ -141,10 +141,6 @@ print_info "Allow egress to Github (optional)"
 # Should be revised periodically - https://api.github.com/meta
 gcloud compute firewall-rules create allow-egress-github --action ALLOW --rules tcp:22,tcp:443 --destination-ranges 192.30.252.0/22,185.199.108.0/22,140.82.112.0/20,143.55.64.0/20,20.201.28.151/32,20.205.243.166/32,102.133.202.242/32,20.248.137.48/32,20.207.73.82/32,20.27.177.113/32,20.200.245.247/32,20.233.54.53/32,20.201.28.152/32,20.205.243.160/32,102.133.202.246/32,20.248.137.50/32,20.207.73.83/32,20.27.177.118/32,20.200.245.248/32,20.233.54.52/32 --direction EGRESS --priority 5001 --network "$NETWORK" --enable-logging
 
-print_info "Allow egress to northamerica-northeast1-a.gce.clouds.archive.ubuntu.com, us-east1.gce.archive.ubuntu.com, security.ubuntu.com for OS updates"
-# Should be revised periodically
-gcloud compute firewall-rules create allow-egress-ubuntu-os-updates --action ALLOW --rules tcp:80,tcp:443 --destination-ranges 35.196.65.164/32,35.196.128.168/32,35.196.235.252/32,91.189.91.81/32,91.189.91.82/32,91.189.91.83/32,91.189.91.121/32,91.189.91.122/32,185.125.190.36/32,185.125.190.38/32,185.125.190.39/32,185.125.190.41/32 --direction EGRESS --priority 5002 --network "$NETWORK" --enable-logging
-
 print_info "Allow egress to internal, peered vpc and secondary ranges"
 gcloud compute firewall-rules create allow-egress-internal --action ALLOW --rules=all --destination-ranges 192.168.0.0/16,172.16.0.128/28,10.0.0.0/8 --direction EGRESS --priority 1000 --network "$NETWORK" --enable-logging
 
@@ -169,17 +165,7 @@ fi
 print_info "Config controller get credentials"
 gcloud anthos config controller get-credentials "$CLUSTER" --location "$REGION"
 
-SA_EMAIL="$(kubectl get ConfigConnectorContext -n config-control \
-    -o jsonpath='{.items[0].spec.googleServiceAccount}' 2> /dev/null)"
+# Further steps
+print_warning "configure-kcc-access.sh script should be run once connectivity to the cluster is established using bastion host / proxy."
 
-print_info "Create organization Admin IAM policy binding"
-gcloud organizations add-iam-policy-binding "${ORG_ID}" \
-  --member="serviceAccount:${SA_EMAIL}" \
-  --role=roles/resourcemanager.organizationAdmin \
-  --condition=None
 
-print_info "Create project IAM policy binding"
-gcloud projects add-iam-policy-binding "${PROJECT_ID}" \
-  --member "serviceAccount:${SA_EMAIL}" \
-  --role "roles/serviceusage.serviceUsageConsumer" \
-  --project "${PROJECT_ID}"

--- a/scripts/bootstrap/setup-kcc.sh
+++ b/scripts/bootstrap/setup-kcc.sh
@@ -152,7 +152,7 @@ print_info "Deny egress to internet"
 gcloud compute firewall-rules create deny-egress-internet --action DENY --rules=all --destination-ranges 0.0.0.0/0 --direction EGRESS --priority 65535 --network "$NETWORK" --enable-logging
 
 print_info "Allow peering to Google Cloud"
-gcloud resource-manager org-policies allow compute.restrictVpcPeering "under:organizations/433637338589" --project $PROJECT_ID
+gcloud resource-manager org-policies allow compute.restrictVpcPeering "under:organizations/433637338589" --project "$PROJECT_ID"
 
 # During testing, I found that I had to wait a bit before policy took effect
 print_info "sleep 30s to allow for policy to update"

--- a/scripts/bootstrap/setup-kcc.sh
+++ b/scripts/bootstrap/setup-kcc.sh
@@ -163,10 +163,11 @@ ENDPOINT='--man-blocks 192.168.0.0/16 --use-private-endpoint'
 if [ "$public_endpoint_opt" = true ]; then
   ENDPOINT=''
 fi
+read -ra args < <(echo "$ENDPOINT")
 if [ "$autopilot_opt" = true ]; then
-  gcloud anthos config controller create "$CLUSTER" --location "$REGION" --network "$NETWORK" --subnet "$SUBNET" --master-ipv4-cidr-block="172.16.0.128/28" --full-management $(echo "$ENDPOINT")
+  gcloud anthos config controller create "$CLUSTER" --location "$REGION" --network "$NETWORK" --subnet "$SUBNET" --master-ipv4-cidr-block="172.16.0.128/28" --full-management "${args[@]}"
 else
-  gcloud anthos config controller create "$CLUSTER" --location "$REGION" --network "$NETWORK" --subnet "$SUBNET" $(echo "$ENDPOINT")
+  gcloud anthos config controller create "$CLUSTER" --location "$REGION" --network "$NETWORK" --subnet "$SUBNET" "${args[@]}"
 fi
 
 print_info "Config controller get credentials"

--- a/scripts/bootstrap/setup-kcc.sh
+++ b/scripts/bootstrap/setup-kcc.sh
@@ -147,9 +147,6 @@ gcloud compute firewall-rules create allow-egress-internal --action ALLOW --rule
 print_info "Deny egress to internet"
 gcloud compute firewall-rules create deny-egress-internet --action DENY --rules=all --destination-ranges 0.0.0.0/0 --direction EGRESS --priority 65535 --network "$NETWORK" --enable-logging
 
-print_info "Allow peering to Google Cloud"
-gcloud resource-manager org-policies allow compute.restrictVpcPeering "under:organizations/433637338589" --project "$PROJECT_ID"
-
 # During testing, I found that I had to wait a bit before policy took effect
 print_info "sleep 30s to allow for policy to update"
 sleep 30


### PR DESCRIPTION
Changes:

- Updated `setup-kcc.sh`:
  - Added firewall rules for ubuntu OS updates (Allow egress to IP addresses for northamerica-northeast1-a.gce.clouds.archive.ubuntu.com, us-east1.gce.archive.ubuntu.com, security.ubuntu.com)
  - Added project level allow policy to enable VPC peering to Google owned organization. This is required for GKE / Anthos control plane access.
  - Updated Anthos config controller to be a private cluster
  - Removed setting up of `git-creds` and `root-sync`.  Since the config controller cluster is private, this cannot be done at this point.  A bastion host / proxy needs to be first provisioned to enable connectivity to the cluster's private endpoint.
- Added a short README file.