### PR TITLE
enable google groups for rbac

### DIFF
--- a/scripts/bootstrap/.env.sample
+++ b/scripts/bootstrap/.env.sample
@@ -11,3 +11,4 @@ export GIT_USERNAME=<Git-Username> # For Azure Devops, this is the name of the O
 export CONFIG_SYNC_REPO=<Repo for Config Sync> # tierX repo URL
 export CONFIG_SYNC_VERSION='HEAD'
 export CONFIG_SYNC_DIR=<Directory for config sync repo which syncs> # Should default to csync/deploy/<env>
+export SECURITY_GROUPS_RBAC=gke-security-groups@<yourdomain.com> # Just change the domain name to match the organization name. Do not change the prefix gke-security-groups 

--- a/scripts/bootstrap/setup-kcc.sh
+++ b/scripts/bootstrap/setup-kcc.sh
@@ -181,6 +181,9 @@ else
   gcloud anthos config controller create "$CLUSTER" --location "$REGION" --network "$NETWORK" --subnet "$SUBNET" "${args[@]}"
 fi
 
+print_info "Enable Google Groups RBAC on config controller cluster"
+gcloud container clusters update "$CLUSTER" --region "$REGION" --security-group "$SECURITY_GROUPS_RBAC"
+
 print_info "Config controller get credentials"
 gcloud anthos config controller get-credentials "$CLUSTER" --location "$REGION"
 


### PR DESCRIPTION
Enabling google groups for rbac based on google technote https://cloud.google.com/kubernetes-engine/docs/how-to/google-groups-rbac#update-existing. Its done post creation of config controller cluster