### PR TITLE
fix: renaming root sync in configure-kcc-access.sh

### DIFF
--- a/scripts/bootstrap/.env.sample
+++ b/scripts/bootstrap/.env.sample
@@ -8,6 +8,7 @@ export ORG_ID=<Organization ID>
 export ROOT_FOLDER_ID=<Folder ID> # This one is only required if using folder_opt (-f) because you are not deploying at the org level. Ex. for testing.
 export BILLING_ID=<Billing ID>
 export GIT_USERNAME=<Git-Username> # For Azure Devops, this is the name of the Organization
+export CONFIG_SYNC_NAME=<Config sync name>
 export CONFIG_SYNC_REPO=<Repo for Config Sync> # tierX repo URL
 export CONFIG_SYNC_VERSION='HEAD'
 export CONFIG_SYNC_DIR=<Directory for config sync repo which syncs> # Should default to csync/deploy/<env>

--- a/scripts/bootstrap/README.md
+++ b/scripts/bootstrap/README.md
@@ -49,4 +49,4 @@ export TOKEN='xxxxxxxxxxxxxxx'
 bash tools/scripts/bootstrap/configure-kcc-access.sh <PATH TO .ENV FILE>
 ```
 
-The script generates a `root-sync.yaml` file.  This file should be checked into the tier1 repo
+The script generates a `gcxm999-csync.yaml` file. This file should be checked into the tier1 repo.

--- a/scripts/bootstrap/README.md
+++ b/scripts/bootstrap/README.md
@@ -49,4 +49,4 @@ export TOKEN='xxxxxxxxxxxxxxx'
 bash tools/scripts/bootstrap/configure-kcc-access.sh <PATH TO .ENV FILE>
 ```
 
-The script generates a `gcxm999-csync.yaml` file. This file should be checked into the tier1 repo.
+The script generates a `root-sync.yaml` file. This file should be checked into the tier1 repo

--- a/scripts/bootstrap/configure-kcc-access.sh
+++ b/scripts/bootstrap/configure-kcc-access.sh
@@ -47,7 +47,7 @@ cat << EOF > ./root-sync.yaml
 apiVersion: configsync.gke.io/v1beta1
 kind: RootSync
 metadata:
-  name: root-sync
+  name: gcxm999-csync
   namespace: config-management-system
 spec:
   sourceFormat: unstructured
@@ -61,8 +61,8 @@ spec:
       name: git-creds
 EOF
 
-print_info "Apply root sync"
-kubectl apply -f root-sync.yaml
+print_info "Apply gcxm999 csync"
+kubectl apply -f gcxm999-csync.yaml
 
 # Further steps
-print_warning "The root-sync.yaml file should be checked into the <tier1-REPO>"
+print_warning "The gcxm999-csync.yaml file should be checked into the <tier1-REPO>"

--- a/scripts/bootstrap/configure-kcc-access.sh
+++ b/scripts/bootstrap/configure-kcc-access.sh
@@ -43,7 +43,7 @@ gcloud projects add-iam-policy-binding "${PROJECT_ID}" \
 print_info "Create git-creds for Repo access"
 kubectl create secret generic git-creds --namespace="config-management-system" --from-literal=username="${GIT_USERNAME}" --from-literal=token="${TOKEN}"
 
-cat << EOF > ./root-sync.yaml
+cat << EOF > ./gcxm999-csync.yaml
 apiVersion: configsync.gke.io/v1beta1
 kind: RootSync
 metadata:

--- a/scripts/bootstrap/configure-kcc-access.sh
+++ b/scripts/bootstrap/configure-kcc-access.sh
@@ -43,11 +43,11 @@ gcloud projects add-iam-policy-binding "${PROJECT_ID}" \
 print_info "Create git-creds for Repo access"
 kubectl create secret generic git-creds --namespace="config-management-system" --from-literal=username="${GIT_USERNAME}" --from-literal=token="${TOKEN}"
 
-cat << EOF > ./gcxm999-csync.yaml
+cat << EOF > ./root-sync.yaml
 apiVersion: configsync.gke.io/v1beta1
 kind: RootSync
 metadata:
-  name: gcxm999-csync
+  name: "${CONFIG_SYNC_NAME}"
   namespace: config-management-system
 spec:
   sourceFormat: unstructured
@@ -61,8 +61,8 @@ spec:
       name: git-creds
 EOF
 
-print_info "Apply gcxm999 csync"
-kubectl apply -f gcxm999-csync.yaml
+print_info "Apply root sync"
+kubectl apply -f root-sync.yaml
 
 # Further steps
-print_warning "The gcxm999-csync.yaml file should be checked into the <tier1-REPO>"
+print_warning "The root-sync.yaml file should be checked into the <tier1-REPO>"


### PR DESCRIPTION
In anticipation of the new group and gcp resource naming convention, we are renaming the `root-sync.yaml` file and its content to support the new naming standard.

root-sync.yaml

```bash
cat << EOF > ./root-sync.yaml
apiVersion: configsync.gke.io/v1beta1
kind: RootSync
metadata:
  name: "${CONFIG_SYNC_NAME}"
  namespace: config-management-system
spec:
  sourceFormat: unstructured
  git:
    repo: "${CONFIG_SYNC_REPO}"
    branch: main # eg. : main
    dir: "${CONFIG_SYNC_DIR}" # eg.: csync/deploy/<env>
    revision: "${CONFIG_SYNC_VERSION}"
    auth: token
    secretRef:
      name: git-creds
EOF
```

https://github.com/ssc-spc-ccoe-cei/gcp-tools/blob/afc4ca65febda9852881180def11b922e4ea5b18/scripts/bootstrap/configure-kcc-access.sh#L46



