### PR TITLE
fix: generate docs bugs

### DIFF
--- a/scripts/common/inventory-controls.py
+++ b/scripts/common/inventory-controls.py
@@ -51,10 +51,12 @@ for root, dirs, files in os.walk('.'):
                 for match in matches:
                     # Load the YAML data from the resource string
                     data = yaml.safe_load(resource)
-                    # Extract the value of the metadata.name node
-                    resource_name = data['metadata']['name']
-                    # Add an item to the inventory list with the security control(match), file type, file name, resource name and details(resource)
-                    inventory.append((match, "kubernetes", os.path.join(root, file), resource_name, resource))
+                    # only continue if the file loaded properly (don't process resources that are commented out)
+                    if data != None:
+                        # Extract the value of the metadata.name node
+                        resource_name = data['metadata']['name']
+                        # Add an item to the inventory list with the security control(match), file type, file name, resource name and details(resource)
+                        inventory.append((match, "kubernetes", os.path.join(root, file), resource_name, resource))
 
         ##################
         # MARKDOWN FILE

--- a/scripts/kpt/generate-docs.sh
+++ b/scripts/kpt/generate-docs.sh
@@ -77,6 +77,11 @@ if [ -f Kptfile ]; then
 
     chmod 777 README.md
 
+    # Work-around when Kptfile pipeline mutators have 'selectors', delete it (in the temp LINUX_WORKDIR).
+    # Error example,
+    # [error]: failed to generate doc: failed to decode Kptfile: invalid 'v1' Kptfile: yaml: unmarshal errors:   line 41: field selectors not found in type v1.Function
+    yq eval 'del(.pipeline.mutators[].selectors)' -i Kptfile
+
     #REPO_URL="${repo}.git${directory}/"
     REPO_URL="${repo}.git${directory%/*}/"
     print_info "running generate-kpt-pkg-docs"


### PR DESCRIPTION
**`inventory-controls.py`** error when parsing YAML resource in comment
```
Traceback (most recent call last):
  File "...myrepo/tools/scripts/kpt/../common/inventory-controls.py", line 55, in <module>
    resource_name = data['metadata']['name']
TypeError: 'NoneType' object is not subscriptable
Script terminating unexpectedly with exit code: 1
```
**fix:** add test to only process valid resources

**`generate-docs.sh`** error when running kpt docs with a Kptfile containing mutators selectors
```
[FAIL] "gcr.io/kpt-fn/generate-kpt-pkg-docs:unstable" in 700ms
  Results:
    [error]: failed to generate doc: failed to decode Kptfile: invalid 'v1' Kptfile: yaml: unmarshal errors:   line 41: field selectors not found in type v1.Function
  Stderr:
    "failed to decode Kptfile: invalid 'v1' Kptfile: yaml: unmarshal errors:"
    "  line 41: field selectors not found in type v1.Function"
  Exit code: 1

Script terminating unexpectedly with exit code: 1
```

**fix:** remove the 'selectors' before running the function in the temp directory